### PR TITLE
Update offline package paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@
 -give user xmmgr access to commands normally restricted to sudo:
 ->>>>>>change /etc/sudoers file with: `username ALL=(ALL) NOPASSWD: command_path`
 ->>>>>>trex_environment.sh needs to be changed from rc5 to rc6 and from docker-dev to docker-trex
+
+### Offline package directory
+The offline installers now look for required `.deb` files in a folder located
+next to the installer script. Place your packages inside a directory named
+`dependencies` when using `install_gui.py` or `offlineInstall` when running
+`offline_install.py` or `offline_install.sh`.

--- a/gui/install_gui.py
+++ b/gui/install_gui.py
@@ -472,7 +472,8 @@ class InstallerGUI(QWidget):
         self.setLayout(self.layout)
     
     def offlineSetup(self):
-        thumb_drive_path = "/home/xmmgr/Downloads/dependencies/"
+        script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+        thumb_drive_path = os.path.join(script_dir, "dependencies")
         print("offlineSetup() function")
 
         # Ensure the thumb drive path exists

--- a/offline/offline_install.py
+++ b/offline/offline_install.py
@@ -61,8 +61,9 @@ class InstallThread(QThread):
     bitbucket_password = ''
     
     def run(self):
-        # Path to the thumb drive (replace with the actual path where your thumb drive is mounted)
-        thumb_drive_path = "/home/xmmgr/Documents/installWizard/offlineInstall/"
+        # Path to the directory containing the installer
+        script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+        thumb_drive_path = os.path.join(script_dir, "offlineInstall")
 
         # Ensure the thumb drive path exists
         if not os.path.exists(thumb_drive_path):

--- a/offline/offline_install.sh
+++ b/offline/offline_install.sh
@@ -5,8 +5,9 @@ sudo apt-get upgrade -y
 
 #!/bin/bash
 
-# Path to the thumb drive (replace with the actual path where your thumb drive is mounted)
-THUMB_DRIVE_PATH="/home/xmmgr/Documents/installWizard/offlineInstall/"
+# Path to the directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+THUMB_DRIVE_PATH="$SCRIPT_DIR/offlineInstall"
 
 # Check if the thumb drive path exists
 if [ ! -d "$THUMB_DRIVE_PATH" ]; then


### PR DESCRIPTION
## Summary
- load offline package dir from the folder of each installer
- document new package folder detection in README

## Testing
- `pytest -q` *(fails: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_684abeaa6ec08325896eef2317517c4e