### PR TITLE
Update offline installer user setup

### DIFF
--- a/gui/install_gui.py
+++ b/gui/install_gui.py
@@ -228,6 +228,7 @@ class InstallerGUI(QWidget):
         ["Making pullinglaunch.sh executable", "chmod", ["+x", "pullinglaunch.sh"]],
         ["Making hosts.sh executable", "chmod", ["+x", "hosts.sh"]],
         ["Running hosts.sh", "sudo", ["./hosts.sh"]],
+        ["Ensure xmmgr user exists", "bash", ["-c", "id -u xmmgr || sudo useradd -m xmmgr && echo 'xmmgr:xmmgr' | sudo chpasswd"]],
         ["Adding docker group", "sudo", ["groupadd", "docker"]],
         ["Forcing adding docker group if it doesn't exist", "sudo", ["groupadd", "-f", "docker"]],
         ["Adding user xmmgr to docker group", "sudo", ["usermod", "-aG", "docker", "xmmgr"]],


### PR DESCRIPTION
## Summary
- add a step in `offline_commands` to create the `xmmgr` user if missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_684afcb518188325b25a11b7ac86a7f9