### PR TITLE
Fix NodeConfigWizard step order

### DIFF
--- a/gui/install_gui.py
+++ b/gui/install_gui.py
@@ -223,11 +223,10 @@ class InstallerGUI(QWidget):
             "-c",
             'if [ -d "/home/xmmgr/launch" ]; then sudo rm -r "/home/xmmgr/launch"; fi'
         ]],  
-        # May remove this for the time being
-        # ["Creating NodeConfigWizard Desktop icon", "bash", [os.path.join(SCRIPT_DIR, "createNodeConfigWizardDesktop.sh")]],
         ["moving launch directory", "tar", ["-xf", os.path.join(SCRIPT_DIR, "launch.tar.gz"), "-C", "/home/xmmgr/"]],
         ["Changing group of launch directory to xmmgr", "sudo", ["chgrp", "-R", "xmmgr", "/home/xmmgr/launch"]],
         ["Changing owner of launch directory to xmmgr", "sudo", ["chown", "-R", "xmmgr", "/home/xmmgr/launch"]],
+        ["Creating NodeConfigWizard Desktop icon", "bash", [os.path.join(SCRIPT_DIR, "createNodeConfigWizardDesktop.sh")]],
 
         # Setting up recordings dir
         ["Creating recordings directory", "mkdir", ["/home/xmmgr/recordings"]],


### PR DESCRIPTION
## Summary
- run createNodeConfigWizardDesktop.sh after extracting `launch.tar.gz`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_684c2c6f83dc8325bf7eb5d8525e9aeb