### PR TITLE
Update desktop entries

### DIFF
--- a/gui/createDesktop.sh
+++ b/gui/createDesktop.sh
@@ -6,9 +6,10 @@ Version=1.0
 Type=Application
 Name=TREX
 Exec=/opt/google/chrome/google-chrome --profile-directory=Default --ignore-profile-directory-if-not-exists http://localhost:8080
-Icon=/home/xmmgr/.config/google-chrome/Default/Web Shortcut Icons/shortcut-306be26dcd328407650ba3e45538492f.png
+Icon="$HOME/git/launch/nodeConfigWizard.png"
 URL=http://localhost:8080
-Comment=Open http://localhost:8080/map in a new tab in Google Chrome."
+Comment=Open http://localhost:8080/map in a new tab in Google Chrome.
+Terminal=false"
 
 # Create the .desktop file on the desktop
 echo "$desktop_entry" > ~/Desktop/localhost.desktop

--- a/gui/createNodeConfigWizardDesktop.sh
+++ b/gui/createNodeConfigWizardDesktop.sh
@@ -8,6 +8,7 @@ Version=1.0
 Type=Application
 Name=Node Config Wizard
 Exec="$node_config_wizard"
+Icon="$HOME/git/launch/nodeConfigWizard.png"
 Terminal=false
 EOT
 

--- a/myscript.desktop
+++ b/myscript.desktop
@@ -4,5 +4,5 @@ Type=Application
 Name=Install TReX
 Comment=Run my Python script
 Exec=/home/xmmgr/git/trexinstaller/gui/dist/install_gui
-#Icon=/home/username/icons/python-icon.png
-Terminal=True
+Icon=/home/xmmgr/git/launch/nodeConfigWizard.png
+Terminal=false


### PR DESCRIPTION
## Summary
- clean up stray shell text
- add icon to node config wizard desktop file
- set Terminal=false for installers and use launch icon
- add execute permission

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_684c2c703b4c8325bcaf5c21584bb1df