### PR TITLE
Improve gather_debs dependency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Before running it, gather all required packages using the provided script.
 
 ### Preparing Offline Packages
 Run `offline/gather_debs.py` to download all packages listed in `packages.csv`.
-The script places the `.deb` files in `offline/debFiles`. Use the optional
-`--tar` flag to create `offline/debFiles.tar.gz` with the downloaded packages.
+The script now uses apt to fetch each package **and all of its dependencies**
+into the `offline/debFiles` directory. Use the optional `--tar` flag to create
+`offline/debFiles.tar.gz` with the downloaded packages.
 Copy these `.deb` files into a folder named `dependencies` alongside the GUI
 executable. The installer reads packages from this directory during the offline
 installation.

--- a/offline/gather_debs.py
+++ b/offline/gather_debs.py
@@ -22,7 +22,20 @@ def download_package(package: str, dest: Path):
         output = dest / 'google-chrome-stable_current_amd64.deb'
         subprocess.run(['wget', '-O', str(output), url], check=True)
     else:
-        subprocess.run(['apt-get', 'download', package], cwd=dest, check=True)
+        # Use apt-get's install command in download-only mode so that
+        # all dependencies of the package are fetched as well.
+        subprocess.run(
+            [
+                'apt-get',
+                'install',
+                '--download-only',
+                '--yes',
+                '-o', f'Dir::Cache={dest}',
+                '-o', f'Dir::Cache::archives={dest}',
+                package,
+            ],
+            check=True,
+        )
 
 
 def create_tarball(src_dir: Path, tar_path: Path):


### PR DESCRIPTION
## Summary
- update gather_debs.py to pull dependencies using apt-get install --download-only
- document that dependencies are downloaded automatically

## Testing
- `python3 -m py_compile offline/gather_debs.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5a3210f88325b32ac56d18f169c8