### PR TITLE
Track .deb order for offline install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Before running it, gather all required packages using the provided script.
 
 ### Preparing Offline Packages
 Run `offline/gather_debs.py` to download all packages listed in `packages.csv`.
-The script now uses apt to fetch each package **and all of its dependencies**
-into the `offline/debFiles` directory. Use the optional `--tar` flag to create
-`offline/debFiles.tar.gz` with the downloaded packages.
+The script uses apt to fetch each package **and all of its dependencies** into
+the `offline/debFiles` directory. It also writes `package_order.txt` inside this
+directory recording the order the `.deb` files were retrieved. Use the optional
+`--tar` flag to create `offline/debFiles.tar.gz` with the downloaded packages.
 After gathering the packages, execute `offline/get_fpga_images.py` to extract
 the X310 and B210 FPGA images from the `uhd-images` package. The images are
 placed in `offline/fpga_images` so they can be copied to the target system
@@ -48,8 +49,9 @@ without requiring internet access.
 
 Copy all `.deb` files into a folder named `dependencies` alongside the GUI
 executable. The installer reads packages from this directory during the offline
-installation. Packages are installed in the same order they are listed in
-`packages.csv`, ensuring a deterministic installation sequence.
+installation. If `package_order.txt` is present in `dependencies` it is used to
+install the packages in the recorded order; otherwise the order from
+`packages.csv` is used to ensure a deterministic installation sequence.
 
 ### Running the Installer in Production
 The compiled GUI installs everything offline using the packages in the

--- a/gui/install_gui.py
+++ b/gui/install_gui.py
@@ -397,41 +397,53 @@ class InstallerGUI(QWidget):
         if not os.path.exists(thumb_drive_path):
             raise FileNotFoundError(f"The thumb drive path {thumb_drive_path} does not exist.")
 
-        packages_path = os.path.join(script_dir, "packages.csv")
-        package_order = []
-        if os.path.exists(packages_path):
-            with open(packages_path, newline="") as f:
-                for row in csv.reader(f):
-                    if not row:
-                        continue
-                    pkg = row[0].strip()
-                    if pkg and not pkg.startswith("#"):
-                        package_order.append(pkg)
-
-        available = [f for f in os.listdir(thumb_drive_path) if f.endswith(".deb")]
+        order_file = os.path.join(thumb_drive_path, "package_order.txt")
         ordered_files = []
-        used = set()
+        if os.path.exists(order_file):
+            with open(order_file) as f:
+                for line in f:
+                    name = line.strip()
+                    if name:
+                        ordered_files.append(name)
+            available = [f for f in os.listdir(thumb_drive_path) if f.endswith(".deb")]
+            for f in sorted(available):
+                if f not in ordered_files:
+                    ordered_files.append(f)
+        else:
+            packages_path = os.path.join(script_dir, "packages.csv")
+            package_order = []
+            if os.path.exists(packages_path):
+                with open(packages_path, newline="") as f:
+                    for row in csv.reader(f):
+                        if not row:
+                            continue
+                        pkg = row[0].strip()
+                        if pkg and not pkg.startswith("#"):
+                            package_order.append(pkg)
 
-        for pkg in package_order:
-            if pkg.endswith(".deb"):
-                name = os.path.basename(pkg)
-                if name in available and name not in used:
-                    ordered_files.append(name)
-                    used.add(name)
-                continue
+            available = [f for f in os.listdir(thumb_drive_path) if f.endswith(".deb")]
+            used = set()
 
-            pattern = f"{pkg}_*.deb"
-            matches = [f for f in available if fnmatch.fnmatch(f, pattern)]
-            if matches:
-                matches.sort()
-                chosen = matches[0]
-                if chosen not in used:
-                    ordered_files.append(chosen)
-                    used.add(chosen)
+            for pkg in package_order:
+                if pkg.endswith(".deb"):
+                    name = os.path.basename(pkg)
+                    if name in available and name not in used:
+                        ordered_files.append(name)
+                        used.add(name)
+                    continue
 
-        for f in sorted(available):
-            if f not in used:
-                ordered_files.append(f)
+                pattern = f"{pkg}_*.deb"
+                matches = [f for f in available if fnmatch.fnmatch(f, pattern)]
+                if matches:
+                    matches.sort()
+                    chosen = matches[0]
+                    if chosen not in used:
+                        ordered_files.append(chosen)
+                        used.add(chosen)
+
+            for f in sorted(available):
+                if f not in used:
+                    ordered_files.append(f)
 
         for deb_file in ordered_files:
             deb_file_path = os.path.join(thumb_drive_path, deb_file)


### PR DESCRIPTION
## Summary
- record the order that packages are downloaded in `gather_debs.py`
- read `package_order.txt` during offline installation so dependencies install in a deterministic order
- document the new `package_order.txt` file in README

## Testing
- `python3 -m py_compile offline/gather_debs.py gui/install_gui.py offline/get_fpga_images.py`

------
https://chatgpt.com/codex/tasks/task_e_684c707edd148325918798085e914366