### PR TITLE
Track .deb order for offline install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ Before running it, gather all required packages using the provided script.
 
 ### Preparing Offline Packages
 Run `offline/gather_debs.py` to download all packages listed in `packages.csv`.
-The script now uses apt to fetch each package **and all of its dependencies**
-into the `offline/debFiles` directory. Use the optional `--tar` flag to create
-`offline/debFiles.tar.gz` with the downloaded packages.
+The script uses apt to fetch each package **and all of its dependencies** into
+the `offline/debFiles` directory. After downloading, it sorts the `.deb` files
+by modification time and writes that sequence to `package_order.txt`. This file
+captures the exact order packages were retrieved so dependencies can be
+installed first. Use the optional `--tar` flag to create `offline/debFiles.tar.gz`
+with the downloaded packages.
 After gathering the packages, execute `offline/get_fpga_images.py` to extract
 the X310 and B210 FPGA images from the `uhd-images` package. The images are
 placed in `offline/fpga_images` so they can be copied to the target system
@@ -48,8 +51,12 @@ without requiring internet access.
 
 Copy all `.deb` files into a folder named `dependencies` alongside the GUI
 executable. The installer reads packages from this directory during the offline
-installation. Packages are installed in the same order they are listed in
-`packages.csv`, ensuring a deterministic installation sequence.
+installation. If `package_order.txt` is present in `dependencies` it is used to
+install the packages in the recorded order; otherwise the order from
+`packages.csv` is used. The `package_order.txt` file ensures dependencies are
+installed before the packages that require them so the installer can simply
+process the list from top to bottom (for example the Python Docker packages will
+appear before the `docker` package).
 
 ### Running the Installer in Production
 The compiled GUI installs everything offline using the packages in the

--- a/offline/gather_debs.py
+++ b/offline/gather_debs.py
@@ -3,6 +3,8 @@ import csv
 import subprocess
 from pathlib import Path
 
+from typing import List
+
 
 def read_packages(csv_path: Path) -> list[str]:
     packages = []
@@ -16,7 +18,11 @@ def read_packages(csv_path: Path) -> list[str]:
     return packages
 
 
-def download_package(package: str, dest: Path):
+def download_package(package: str, dest: Path) -> List[str]:
+    """Download *package* and return the list of newly created .deb files in
+    the order they were retrieved."""
+    before = {p.name: p.stat().st_mtime for p in dest.glob('*.deb')}
+
     if package.startswith('./google-chrome-stable_current_amd64.deb'):
         url = 'https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb'
         output = dest / 'google-chrome-stable_current_amd64.deb'
@@ -37,6 +43,11 @@ def download_package(package: str, dest: Path):
             check=True,
         )
 
+    after = {p.name: p.stat().st_mtime for p in dest.glob('*.deb')}
+    new = [(name, after[name]) for name in after.keys() - before.keys()]
+    new.sort(key=lambda t: t[1])
+    return [name for name, _ in new]
+
 
 def create_tarball(src_dir: Path, tar_path: Path):
     subprocess.run(['tar', '-czvf', str(tar_path), '-C', str(src_dir), '.'], check=True)
@@ -53,11 +64,19 @@ def main():
     download_dir.mkdir(parents=True, exist_ok=True)
 
     packages = read_packages(packages_file)
+    seen = {}
     for package in packages:
         try:
-            download_package(package, download_dir)
+            new_files = download_package(package, download_dir)
+            for fname in new_files:
+                seen[fname] = (download_dir / fname).stat().st_mtime
         except subprocess.CalledProcessError as exc:
             print(f"Failed to download {package}: {exc}")
+
+    order_path = download_dir / 'package_order.txt'
+    with order_path.open('w') as order_file:
+        for name, _ in sorted(seen.items(), key=lambda item: item[1]):
+            order_file.write(name + '\n')
 
     if args.tar:
         tar_path = script_dir / 'debFiles.tar.gz'


### PR DESCRIPTION
## Summary
- capture downloaded package order using file modification times
- remove explicit Docker/Python reorder logic
- document package ordering in README

## Testing
- `python3 -m py_compile offline/gather_debs.py gui/install_gui.py offline/get_fpga_images.py`


------
https://chatgpt.com/codex/tasks/task_e_684c707edd148325918798085e914366