### PR TITLE
Update launch directory handling

### DIFF
--- a/gui/createNodeConfigWizardDesktop.sh
+++ b/gui/createNodeConfigWizardDesktop.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-[ -n "$NODE_WIZARD_USER" ] && HOME="/home/$NODE_WIZARD_USER"
+NODE_WIZARD_USER="${NODE_WIZARD_USER:-xmmgr}"
+HOME="/home/$NODE_WIZARD_USER"
 
 node_config_wizard="$HOME/launch/nodeConfigWizard"
 desktop_file="/usr/share/applications/nodeConfigWizard.desktop"

--- a/gui/install_gui.py
+++ b/gui/install_gui.py
@@ -322,7 +322,10 @@ class InstallerGUI(QWidget):
             if cmd[1] == "sudo" and (not cmd[2] or cmd[2][0] != "-S"):
                 cmd[2].insert(0, "-S")
 
-        self.launch_parent_dir = os.path.join(os.path.expanduser("~"), "git")
+        # The launch directory should always live inside the xmmgr user's
+        # home directory.  Default to ``/home/xmmgr/launch`` so no dialog is
+        # required to pick the location.
+        self.launch_parent_dir = "/home/xmmgr"
         self.launch_dir = os.path.join(self.launch_parent_dir, "launch")
         self.current_command = ""
         self.initUI()
@@ -611,14 +614,8 @@ class InstallerGUI(QWidget):
 
 
     def request_launch_location(self):
-        default_dir = self.launch_parent_dir
-        selected_dir = QFileDialog.getExistingDirectory(
-            self,
-            "Select Launch Directory Location",
-            default_dir,
-        )
-        if selected_dir:
-            self.launch_parent_dir = selected_dir
+        """Set the launch directory to the xmmgr user's home."""
+        self.launch_parent_dir = "/home/xmmgr"
         self.launch_dir = os.path.join(self.launch_parent_dir, "launch")
         print("launch directory set to", self.launch_dir)
     


### PR DESCRIPTION
## Summary
- default the installer launch directory to `/home/xmmgr/launch`
- stop prompting for launch directory
- default Node Config Wizard desktop script to use xmmgr home

## Testing
- `python3 gui/test_commands.py` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_685095be58fc83259be95b3f59a7014c